### PR TITLE
Remove orphaned tracks and channels on user delete

### DIFF
--- a/supabase/migrations/20240418145338_initial_schema.sql
+++ b/supabase/migrations/20240418145338_initial_schema.sql
@@ -1,5 +1,7 @@
 -- Add PostGIS extension for geography data types (the map)
+set pgaudit.log = 'none';
 create extension if not exists postgis schema extensions;
+set pgaudit.log = 'ddl';
 
 -- Drop exisiting tables
 DROP TABLE if exists public.accounts;

--- a/supabase/migrations/20240511100626_delete-orphan-rows.sql
+++ b/supabase/migrations/20240511100626_delete-orphan-rows.sql
@@ -14,6 +14,6 @@ AS $$
 	delete from channels where id not in (select channel_id from user_channel);
 
 	-- Delete any orphaned tracks
-	delete from tracks where track_id not in (select track_id from channel_track);
+	delete from tracks where id not in (select track_id from channel_track);
 $$;
 

--- a/supabase/migrations/20240511100626_delete-orphan-rows.sql
+++ b/supabase/migrations/20240511100626_delete-orphan-rows.sql
@@ -1,0 +1,19 @@
+-- Create a procedure to delete the authenticated user
+CREATE or replace function delete_user()
+	returns void
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+	-- Delete user's associations with channels
+	delete from user_channel where user_id = auth.uid();
+
+	-- Delete account and user
+	delete from accounts where id = auth.uid();
+	delete from auth.users where id = auth.uid();
+
+	-- Delete any orphaned channels
+	delete from channels where id not in (select channel_id from user_channel);
+
+	-- Delete any orphaned tracks
+	delete from tracks where track_id not in (select track_id from channel_track);
+$$;
+


### PR DESCRIPTION
This replaces the already existing `delete_user()` function.

It will now also

- explicitly delete the `account`
- delete any orphaned channels or tracks when `delete_user()` is called

If you delete a channel, but not your user, tracks are still not removed, since they might be referenced by other channel_tracks. BUT, on the next `delete_user()` call it'll be cleaned up. 

---

As an alternative to this approach, we could disable the multi-channel/track schema for now. Add user_id to channels and channel_id to tracks. Then we can clean it up easy with SQL cascades, and don't need this stuff.