### PR TITLE
Change GitHub action to run for prod branch instead of release

### DIFF
--- a/.github/workflows/supabase-deploy-dev.yml
+++ b/.github/workflows/supabase-deploy-dev.yml
@@ -1,16 +1,14 @@
 name: Supabase push migrations to production
 
 on:
-  release:
-    types: [created]
-    tags:
-      - 'v*.*.*'
+  push:
+    branches: 
+     - prod
 
 env:
   SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
   SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
   SUPABASE_PROJECT_ID: ${{ env.SUPABASE_DB_PASSWORD }}
-
 
 jobs:
   supabase-push:


### PR DESCRIPTION
Pushing to the `prod` branch requires an approved pull request from one of us.

This changes the workflow to run whenever that happens, also see https://supabase.com/docs/guides/cli/managing-environments?queryGroups=environment&environment=production#configure-github-actions.