### PR TITLE
add: `duration` on `tracks` (in seconds)

### DIFF
--- a/supabase/migrations/20251203141352_tracks_duration.sql
+++ b/supabase/migrations/20251203141352_tracks_duration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE IF EXISTS public.tracks
+ADD COLUMN duration INTEGER;
+
+COMMENT ON COLUMN public.tracks.duration
+    IS 'Duration of the track in seconds (nullable if unavailable, for exemple when track media is broken)';


### PR DESCRIPTION
For #30, add the `duration` on the `tracks` table to have available the `track.duration` information (in seconds).

That way we can for example make the automatic-live-radio, base on the entire list of track and their duration.