### PR TITLE
add: `playback_error` on `tracks` (TEXT) in case a user shoud fix it

### DIFF
--- a/supabase/migrations/20251203143008_tracks_playback_error.sql
+++ b/supabase/migrations/20251203143008_tracks_playback_error.sql
@@ -1,0 +1,5 @@
+ALTER TABLE IF EXISTS public.tracks
+ADD COLUMN playback_error TEXT;
+
+COMMENT ON COLUMN public.tracks.playback_error
+  IS 'Non-null when last playback attempt failed; may contain provider error message or code';


### PR DESCRIPTION
For #30, we want to store the fact that the `track` encountered an error while the user (owner) tried to play it.

With this PR we are now storing it as `playback_error` as `TEXT` (nullable).

# Rationale

- Errors can come from many providers (youtube, 
- We don’t really care about the exact provider error right now
- We mainly want: “this track is broken, please review”

A **nullable text field** works really well:

* `NULL` → no known error (last play attempt was OK or never tried)
* Non-NULL → there *was* an error; optionally store a short message or code

Good name ideas:

* `playback_error` (my favourite: clear and specific)
* `last_error`
* `error_message` (a bit vague)
*  `error` to be avoided, because it’s not very descriptive once we see it in queries or logs

# How we’d use it in code:

* When the player **fails** to play:
  `UPDATE tracks SET playback_error = 'Unsupported provider: xyz || Broken media etc.' WHERE id = ...;`
* When it later **plays successfully** or the user fixes it (URL fixed, region OK, etc.):
  `UPDATE tracks SET playback_error = NULL WHERE id = ...;`