### PR TITLE
fix: github action supabase dev push

### DIFF
--- a/.github/workflows/supabase-deploy-dev.yml
+++ b/.github/workflows/supabase-deploy-dev.yml
@@ -8,11 +8,15 @@ on:
 env:
   SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
   SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-  SUPABASE_PROJECT_ID: ${{ env.SUPABASE_DB_PASSWORD }}
+  SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
 
 jobs:
   supabase-push:
+    runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: supabase/setup-cli@v1
-      - run: supabase link --project-ref $PROJECT_ID
+        with:
+          version: latest
+      - run: supabase link --project-ref $SUPABASE_PROJECT_ID
       - run: supabase db push


### PR DESCRIPTION
Try and fix the extisting github action to push to supabase dev env.

But is this action needed at all? It seems that all PR show supabase integration, it links to https://supabase.com/docs/guides/deployment/branching
<img width="1216" height="492" alt="image" src="https://github.com/user-attachments/assets/a9dcfa2d-463e-4697-b56a-a45062390fac" />
