### PR TITLE
Fix for RLS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "supabase": "^2.72.6"
+    "supabase": "^2.72.8"
   }
 }

--- a/supabase/migrations/20260121120000_fix_is_banned_permissions.sql
+++ b/supabase/migrations/20260121120000_fix_is_banned_permissions.sql
@@ -1,0 +1,15 @@
+-- Fix: is_banned() needs security definer to read auth.users
+create or replace function public.is_banned()
+	returns boolean
+	language sql
+	stable
+	security definer
+	set search_path = public
+as $$
+	select exists (
+		select 1
+		from auth.users
+		where id = auth.uid()
+			and banned_until > now()
+	);
+$$;


### PR DESCRIPTION
the `public.is_banned()` method wasn't working because it queries `auth.users` which is a table that requires `security definer` to read.